### PR TITLE
Clone all repos + add code-workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,14 @@
-wtt_front
-wtt_db
-wtt_server
-wtt_vectortiles
-wtt_notifications
+# waterthetrees repos
+tree-id/
+wtt_allometry/
+wtt_area/
+wtt_db/
+wtt_front/
+wtt_notifications/
+wtt_server/
+wtt_vectortiles/
+
+# Mac OS
 .DS_Store
 
 # Logs

--- a/clone_repos.sh
+++ b/clone_repos.sh
@@ -10,17 +10,26 @@ curl -s https://$USERNAME:$TOKEN@api.github.com/orgs/$ORG/repos?per_page=100 | j
 mv wtt* $ORG/
 
 # On windows?
-# Clones martin
-[[ -d wtt_vectortiles ]] || git clone https://github.com/waterthetrees/wtt_vectortiles.git
+# Clones tree-id (npm package)
+[[ -d tree-id ]] || git clone https://github.com/waterthetrees/tree-id.git
 
-# Clones server
-[[ -d wtt_server ]] || git clone https://github.com/waterthetrees/wtt_server.git
+# Clones allometry (carbon calculator)
+[[ -d wtt_allometry ]] || git clone https://github.com/waterthetrees/wtt_allometry.git
 
-# Clones frontend
-[[ -d wtt_front ]] || git clone https://github.com/waterthetrees/wtt_front.git
+# Clones area
+[[ -d wtt_area ]] || git clone https://github.com/waterthetrees/wtt_area.git
 
 # Clones db
 [[ -d wtt_db ]] || git clone https://github.com/waterthetrees/wtt_db.git
 
+# Clones frontend
+[[ -d wtt_front ]] || git clone https://github.com/waterthetrees/wtt_front.git
+
 # Clones notifications
 [[ -d wtt_notifications ]] || git clone https://github.com/waterthetrees/wtt_notifications.git
+
+# Clones server
+[[ -d wtt_server ]] || git clone https://github.com/waterthetrees/wtt_server.git
+
+# Clones vectortiles (martin)
+[[ -d wtt_vectortiles ]] || git clone https://github.com/waterthetrees/wtt_vectortiles.git

--- a/waterthetrees.code-workspace
+++ b/waterthetrees.code-workspace
@@ -1,0 +1,20 @@
+// Use this workspace to focus only your selected repos
+{
+	"folders": [
+		{
+			"path": "wtt_front",
+		},
+		{
+			"path": "wtt_server",
+		}
+		// Feel free to add or remove folders depending on what you're currently working on
+	],
+	"extensions": {
+		"recommendations": [
+			"dbaeumer.vscode-eslint",
+			"editorconfig.editorconfig",
+			"esbenp.prettier-vscode",
+			"rangav.vscode-thunder-client"
+		]
+	}
+}


### PR DESCRIPTION
Update clone_repos.sh script to clone all repos under the waterthetrees organization and add them to the .gitignore (I also alphabetized the list). Even if people might not ever work in some of these, I think it's better to give new members everything up front and let them explore the code. It also was a point of confusion for me why certain repos were cloned on initial set up and others were not.

I also added a .code-workspace file that people can modify locally to fit their current task. When you open the file, there is a "Open Workspace" button on the bottom right. When you click that button, a workspace with the folders listed in your .code-workspace file opens.

![image](https://user-images.githubusercontent.com/6326660/179697390-b3e81baa-916a-45c4-a32b-ce6e546d1639.png)

![image](https://user-images.githubusercontent.com/6326660/179697698-8c34cd9e-09eb-487d-9327-b574bcf32e4e.png)
