### PR TITLE
Change npm install to npm ci (wtt_server)

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ instructions please create an issue with the details of your problem on our
     ```
 
 4. The database config is passed into our backend server using
-[environment variables](https://github.com/waterthetrees/wtt_server/blob/development/server/db/db-config.js#L8-L12).
+[environment variables](https://github.com/waterthetrees/wtt_server/blob/main/server/db/db-config.js#L8-L12).
 You will need to ask a team member to provide you with the environment variables
 (Try our [Slack channel](#join-us)). Paste the contents into the `wtt_server/.env` file.
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ instructions please create an issue with the details of your problem on our
     ```shell
     cd wtt_server
     cp .env.example .env
-    npm install
+    npm ci
     cd ..
     ```
 

--- a/install.sh
+++ b/install.sh
@@ -26,7 +26,7 @@ cd ..
 # Backend set up
 echo -e "\n${GREEN}Setting up wtt_server...${RESET_COLOR}"
 cd wtt_server
-npm install
+npm ci
 cp .env.example .env
 cd ..
 


### PR DESCRIPTION
Change `npm install` command to `npm ci` only for places related to `wtt_server`. This is related to the changes in waterthetrees/wtt_server#113.

Closes #25