### PR TITLE
fix(clone_repos): not looping thru all repos

### DIFF
--- a/clone_repos.sh
+++ b/clone_repos.sh
@@ -25,7 +25,7 @@ clone_repo() {
 }
 
 clone_all_repos() {
-  for i in $REPOS; 
+  for i in ${REPOS[@]}; 
     do clone_repo $i; 
   done
 }


### PR DESCRIPTION
### Summary
The syntax for the for loop in `clone_all_repos()` is incorrect and it only loops thru the first element. Now with this change we will loop thru all the repos.