### PR TITLE
Remove extra cd command in install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -63,5 +63,4 @@ cd ..
 
 # Start Dockers
 echo -e "\n${GREEN}Starting dockers...${RESET_COLOR}"
-cd ..
 docker compose up


### PR DESCRIPTION
`install.sh` seems to have one extra `cd ..` invocation, which puts us one directory level higher than we want to be (the `cd ..` in the "Db set up" section already puts in the project root). Specifically, `docker compose` does not find a `docker-compose.yml` file in that directory, with this result:

```
Starting dockers...
no configuration file provided: not found
```

After :

```
Starting dockers...
[+] Running 2/0
 ✔ Container wtt_postgis  Created                                  0.0s 
 ✔ Container wtt_server   Created 
```